### PR TITLE
Add pages for all app reviewers

### DIFF
--- a/app-reviewers/awario.md
+++ b/app-reviewers/awario.md
@@ -1,0 +1,6 @@
+#Awario
+
+Awario is a reviewer of online reach and awareness. The general description will be hosted on docs.blockstack.org. 
+Currently, there is an open issue for that: https://github.com/blockstack/docs.blockstack/issues/164
+
+The score does not include any decentralized online media.

--- a/app-reviewers/de.md
+++ b/app-reviewers/de.md
@@ -1,0 +1,4 @@
+#Democracy Earth
+Democracy Earth is a reviewer of app value for the ecosystem. The general description is available on https://docs.blockstack.org/develop/mining_intro.html#democracy-earth
+
+The reviewer has been added already in the very first alpha run. It was paused in Mai 2019 as described in https://github.com/blockstack/app-mining/issues/92

--- a/app-reviewers/nil.md
+++ b/app-reviewers/nil.md
@@ -1,0 +1,7 @@
+#New Internet Labs
+
+New Internet Labs is a digital rights reviewer. The reviewer evaluates the use of Blockstack Auth and Gaia.
+The general description will be hosted on docs.blockstack.org. Currently, there is an open issue for that: https://github.com/blockstack/docs.blockstack/issues/176
+
+The rating for using Blockstack Auth is document in https://github.com/blockstack/app-mining/blob/master/DigitalRightsAuthScoringCriteria.pdf
+

--- a/app-reviewers/ph.md
+++ b/app-reviewers/ph.md
@@ -1,0 +1,7 @@
+#Product Hunt
+Product Hunt is a reviewer of innovation. The general description is available on https://docs.blockstack.org/develop/mining_intro.html#product-hunt
+
+The score is calculated with a 90% monthly decay to your Product Hunt total upvotes. This will make a single big launch count less over time. 
+You can re-hunt your app every ~6ish months if your app has significant changes.
+
+The metric takes into account your number of new credible upvotes since last month.


### PR DESCRIPTION
This PR
* adds a page for New Internet Labs, Awario, Product Hunt, Democracy Earth.

The purpose of these pages is to help discussing particular issues and clarify rules applied by the reviewers. All information that is not relevant to the algorithm specification shall be hosted on docs.blockstack.org

* fixes #46, fixes #89   