### PR TITLE
Add section about impact on game theory

### DIFF
--- a/.github/ISSUE_TEMPLATE/app-mining-improvement-proposal.md
+++ b/.github/ISSUE_TEMPLATE/app-mining-improvement-proposal.md
@@ -19,6 +19,9 @@ A clear and concise description of the improvement to be made, typically an App 
 **What is the dry run period (if any)**
 Important changes can take effect without dry run period directly at the beginning of the next review period. Changes with uncertain effects can be run in dry run mode for several months.
 
+**What is the impact on the game?**
+Estimate the impact of the change on the game theory behind app mining. Ot state why game theorists need not review this change.
+
 **Describe your long term considerations in proposing this change. Please include the ways you can predict this recommendation could go wrong and possible ways mitigate.**
 A clear and concise description of the thought experiment you’ve gone through to roll this out: please keep in mind it may need to scale and cannot be easily gamed. Please list any remaining open questions to be solved in proposing the change, if any. 
 


### PR DESCRIPTION
There are a few changes recently that have impacted or could impact the game theory behind app mining. In particular with regards to the goal of automating the process as much as possible, review of changes by game theorists should be the default.

This pull request adds a section in the template about the impact on game theory.